### PR TITLE
docs: linki do hostowanej dokumentacji + bump 1.4.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,14 @@ A **pure Dart** library for generating **Microsoft Word (DOCX)** and **PDF** doc
 
 > If you find this package useful, please consider giving it a [star on GitHub](https://github.com/erykkruk/docs_gee) and a [like on pub.dev](https://pub.dev/packages/docs_gee). It helps the package grow and stay maintained!
 
+## Documentation
+
+Full hosted documentation is available at [codigee.com/open-source/docs-gee](https://codigee.com/open-source/docs-gee):
+
+- **[Overview](https://codigee.com/open-source/docs-gee)** - what docs_gee is and why to use it
+- **[Document building guide](https://codigee.com/open-source/docs-gee/guide)** - step-by-step guide to building DOCX and PDF documents
+- **[DocxReader & API reference](https://codigee.com/open-source/docs-gee/api)** - full API reference and `DocxReader` docs ([markdown source](docx_generator/doc/api.md))
+
 ## Why docs_gee?
 
 - **Pure Dart** - No native dependencies, works everywhere Dart runs

--- a/docx_generator/CHANGELOG.md
+++ b/docx_generator/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.4.1] - 2026-07-10
+
+### Changed
+- Added a **Documentation** section to the README linking the hosted docs at
+  [codigee.com/open-source/docs-gee](https://codigee.com/open-source/docs-gee):
+  overview, document-building guide, and the DocxReader & API reference.
+
 ## [1.4.0] - 2026-07-10
 
 ### Added

--- a/docx_generator/README.md
+++ b/docx_generator/README.md
@@ -9,6 +9,14 @@ A **pure Dart** library for generating **Microsoft Word (DOCX)** and **PDF** doc
 
 > If you find this package useful, please consider giving it a [star on GitHub](https://github.com/erykkruk/docs_gee) and a [like on pub.dev](https://pub.dev/packages/docs_gee). It helps the package grow and stay maintained!
 
+## Documentation
+
+Full hosted documentation is available at [codigee.com/open-source/docs-gee](https://codigee.com/open-source/docs-gee):
+
+- **[Overview](https://codigee.com/open-source/docs-gee)** - what docs_gee is and why to use it
+- **[Document building guide](https://codigee.com/open-source/docs-gee/guide)** - step-by-step guide to building DOCX and PDF documents
+- **[DocxReader & API reference](https://codigee.com/open-source/docs-gee/api)** - full API reference and `DocxReader` docs ([markdown source](doc/api.md))
+
 ## Why docs_gee?
 
 - **Pure Dart** - No native dependencies, works everywhere Dart runs

--- a/docx_generator/pubspec.yaml
+++ b/docx_generator/pubspec.yaml
@@ -1,6 +1,6 @@
 name: docs_gee
 description: Pure Dart library for generating and reading DOCX and PDF documents with rich formatting, tables, lists. Cross-platform with no native dependencies.
-version: 1.4.0
+version: 1.4.1
 
 homepage: https://github.com/erykkruk/docs_gee
 repository: https://github.com/erykkruk/docs_gee


### PR DESCRIPTION
## Podsumowanie

Dodaje sekcję **Documentation** do obu plików README (root oraz `docx_generator/`), linkującą do hostowanej dokumentacji na codigee.com, oraz podbija wersję pakietu do **1.4.1**.

## Zmiany

- **README.md** oraz **docx_generator/README.md** — nowa sekcja `## Documentation` (zaraz po intro/badge'ach) z trzema linkami:
  - Overview — https://codigee.com/open-source/docs-gee
  - Document building guide — https://codigee.com/open-source/docs-gee/guide
  - DocxReader & API reference — https://codigee.com/open-source/docs-gee/api
  - Lokalny `doc/api.md` pozostaje jako odnośnik "(markdown source)".
- **docx_generator/pubspec.yaml** — `version: 1.4.0` → `1.4.1`.
- **docx_generator/CHANGELOG.md** — wpis `## [1.4.1] - 2026-07-10`.

## Uwaga o CI (publikacja)

Repo ma zautomatyzowany pipeline release'u: `release.yml` odpala się na push do `main` i taguje `v1.4.1`, a `publish.yml` na tagu publikuje pakiet na pub.dev. Merge tej PR-ki spowoduje więc realną publikację **docs_gee 1.4.1** na pub.dev.