### PR TITLE
chore(docs): link pub.dev do hostowanych docsów codigee.com

### DIFF
--- a/docx_generator/CHANGELOG.md
+++ b/docx_generator/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.4.2] - 2026-07-10
+
+### Changed
+- Set the pubspec `documentation:` field so the pub.dev "Documentation" link
+  points to the hosted docs at codigee.com/open-source/docs-gee.
+
 ## [1.4.1] - 2026-07-10
 
 ### Changed

--- a/docx_generator/pubspec.yaml
+++ b/docx_generator/pubspec.yaml
@@ -1,9 +1,10 @@
 name: docs_gee
 description: Pure Dart library for generating and reading DOCX and PDF documents with rich formatting, tables, lists. Cross-platform with no native dependencies.
-version: 1.4.1
+version: 1.4.2
 
 homepage: https://github.com/erykkruk/docs_gee
 repository: https://github.com/erykkruk/docs_gee
+documentation: https://codigee.com/open-source/docs-gee
 
 topics:
   - docx


### PR DESCRIPTION
Ustawia pole `documentation:` w pubspec (docx_generator/) na codigee.com/open-source/docs-gee, żeby link "Documentation" na pub.dev prowadził na hostowane docsy.

- bump 1.4.1 → 1.4.2
- wpis w CHANGELOG

Po mergu Release CI otaguje v1.4.2 i opublikuje na pub.dev (zamierzone).